### PR TITLE
import os for line 66

### DIFF
--- a/model_utils.py
+++ b/model_utils.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import os
 import re
 import numpy as np
 import six


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/zihangdai/xlnet on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./tpu_estimator.py:2902:10: F821 undefined name 'rte'
  loss = rte[0]
         ^
./model_utils.py:65:18: F821 undefined name 'os'
      ckpt_dir = os.path.dirname(FLAGS.init_checkpoint)
                 ^
./prepro_utils.py:29:27: F821 undefined name 'unicode'
    elif isinstance(text, unicode):
                          ^
./prepro_utils.py:72:35: F821 undefined name 'unicode'
  if six.PY2 and isinstance(text, unicode):
                                  ^
./run_squad.py:450:36: F821 undefined name 'unicode'
      if six.PY2 and isinstance(x, unicode):
                                   ^
5     F821 undefined name 'os'
5
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree