### PR TITLE
add condition which is only use fwd_pos_emb when bsz is one

### DIFF
--- a/modeling.py
+++ b/modeling.py
@@ -232,6 +232,8 @@ def relative_positional_encoding(qlen, klen, d_model, clamp_len, attn_type,
       bwd_pos_seq = tf.clip_by_value(bwd_pos_seq, -clamp_len, clamp_len)
 
     if bsz is not None:
+      # With bi_data, the batch size should be divisible by 2.
+      assert bsz%2 == 0
       fwd_pos_emb = positional_embedding(fwd_pos_seq, inv_freq, bsz//2)
       bwd_pos_emb = positional_embedding(bwd_pos_seq, inv_freq, bsz//2)
     else:


### PR DESCRIPTION
In `modeling.py`, There are some error, when batch size is one, because bsz(1) is divided by 2 so, it'll be zero. So, positional_embedding is made as [seq_len, 2, ..] shape.
It occurs dimension error in `einsum`, [modeling.py#137](https://github.com/zihangdai/xlnet/blob/d8c6232add2aa2bf71960d072203cdfa17c0ef79/modeling.py#L137).
`bd = tf.einsum('ibnd,jbnd->ijbn', q_head + r_r_bias, k_head_r)`
first 'b' and second 'b' is not matched
Thanks!
```python
  if bi_data and bsz is not 1:
    fwd_pos_seq = tf.range(beg, end, -1.0)
    bwd_pos_seq = tf.range(-beg, -end, 1.0)

    if dtype is not None and dtype != tf.float32:
      fwd_pos_seq = tf.cast(fwd_pos_seq, dtype=dtype)
      bwd_pos_seq = tf.cast(bwd_pos_seq, dtype=dtype)

    if clamp_len > 0:
      fwd_pos_seq = tf.clip_by_value(fwd_pos_seq, -clamp_len, clamp_len)
      bwd_pos_seq = tf.clip_by_value(bwd_pos_seq, -clamp_len, clamp_len)

    if bsz is not None:
      fwd_pos_emb = positional_embedding(fwd_pos_seq, inv_freq, bsz//2)
      bwd_pos_emb = positional_embedding(bwd_pos_seq, inv_freq, bsz//2)
    else:
      fwd_pos_emb = positional_embedding(fwd_pos_seq, inv_freq)
      bwd_pos_emb = positional_embedding(bwd_pos_seq, inv_freq)

    pos_emb = tf.concat([fwd_pos_emb, bwd_pos_emb], axis=1)
```