### PR TITLE
Fixed code to use AdamWeightDecayOptimizer

### DIFF
--- a/model_utils.py
+++ b/model_utils.py
@@ -166,7 +166,8 @@ def get_train_op(FLAGS, total_loss, grads_and_vars=None):
       zip(clipped, variables), global_step=global_step)
 
   # Manually increment `global_step` for AdamWeightDecayOptimizer
-  if isinstance(optimizer, AdamWeightDecayOptimizer):
+  # weight_decay will not be zero only when AdamWeightDecayOptimizer is used
+  if FLAGS.weight_decay != 0:
     new_global_step = global_step + 1
     train_op = tf.group(train_op, [global_step.assign(new_global_step)])
 


### PR DESCRIPTION
Made changes to the code [here](https://github.com/zihangdai/xlnet/blob/master/model_utils.py#L169).
This was done because when the code reaches the said line, the optimizer is not necessarily a  AdamWeightDecayOptimizer object. It can be a CrossShardOptimizer object.
Thus, by change checking if the weight_decay flag is not equal to zero, we can conclusively say if the optimizer uses Adam weight decay or not.

Note: `if FLAGS.weight_decay != 0` can be changed to `if not FLAGS.weight_decay` but that would hinder the code if someone has used `None`  by mistake