### PR TITLE
Fix AdamW under TPU device

### DIFF
--- a/model_utils.py
+++ b/model_utils.py
@@ -166,7 +166,7 @@ def get_train_op(FLAGS, total_loss, grads_and_vars=None):
       zip(clipped, variables), global_step=global_step)
 
   # Manually increment `global_step` for AdamWeightDecayOptimizer
-  if isinstance(optimizer, AdamWeightDecayOptimizer):
+  if FLAGS.weight_decay > 0:
     new_global_step = global_step + 1
     train_op = tf.group(train_op, [global_step.assign(new_global_step)])
 


### PR DESCRIPTION
Hi @zihangdai  @kimiyoung ,

A few weeks ago, I reported the bugs about weight decay optimizer, refer to #66.
Recently, I found it was fixed and I appreciate that.
However, current AdamW optimizer may still fail under TPU.
See: https://github.com/zihangdai/xlnet/blob/master/model_utils.py#L169
If we use TPU, then the `optimizer` may NOT be an instance of `AdamWeightDecayOptimizer`, as it will be wrapped by `tf.contrib.tpu.CrossShardOptimizer(optimizer)`( see https://github.com/zihangdai/xlnet/blob/master/model_utils.py#L141). This will cause the optimizer step NEVER increase. 
A fast solution is to just compare the `FLAGS.weight_decay > 0`, which is fine for both GPU and TPU.
I've create a quick fix here, FYI. As I won't touch this fork, you can merge it whenever you wish.