### PR TITLE
Config for TPU pod

### DIFF
--- a/model_utils.py
+++ b/model_utils.py
@@ -19,7 +19,7 @@ def configure_tpu(FLAGS):
   if FLAGS.use_tpu:
     tpu_cluster = tf.contrib.cluster_resolver.TPUClusterResolver(
         FLAGS.tpu, zone=FLAGS.tpu_zone, project=FLAGS.gcp_project)
-    master = tpu_cluster.get_master()
+    master = None
   else:
     tpu_cluster = None
     master = FLAGS.master
@@ -42,6 +42,7 @@ def configure_tpu(FLAGS):
 
   per_host_input = tf.contrib.tpu.InputPipelineConfig.PER_HOST_V2
   run_config = tf.contrib.tpu.RunConfig(
+      cluster=tpu_cluster,
       master=master,
       model_dir=FLAGS.model_dir,
       session_config=session_config,


### PR DESCRIPTION
I ran `train.py` on a TPU pod v3-256 and got the following error:

    ValueError: TPUConfig.num_shards is not set correctly ....

Found in https://cloud.google.com/tpu/docs/training-on-tpu-pods#providing_the_tpu_name_and_region_to_tpuclusterresolver that
> For single device training, you can specify either the TPU name or an IP address, for example: `grpc://1.2.3.4:8470`.
> For TPU Pods you must use the TPU name so that TensorFlow can discover the IP addresses of all the hosts available for training distribution.

So, in the case of a TPU pod, setting `master` doesn't work. I just tried setting `cluster` and it worked, all 32 hosts in the TPU pod were detected and used correctly.